### PR TITLE
incremental order_data_by_order_date_general stream

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/integration_tests/configured_catalog_get_flat_file_all_orders_data_by_order_date_general.json
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/integration_tests/configured_catalog_get_flat_file_all_orders_data_by_order_date_general.json
@@ -1,0 +1,382 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "GET_FLAT_FILE_ALL_ORDERS_DATA_BY_ORDER_DATE_GENERAL",
+        "json_schema": {
+          "title": "Flat File All Orders Data Reports",
+          "description": "Flat File All Orders Data by Order Date General Reports",
+          "type": "object",
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "properties": {
+            "order-id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "order-item-id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "purchase-date": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "payments-date": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "buyer-email": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "buyer-name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "sku": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "product-name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "quantity-purchased": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "currency": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "item-price": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "shipping-price": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "item-tax": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ship-service-level": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "recipient-name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ship-address-1": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ship-address-2": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ship-address-3": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ship-city": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ship-state": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ship-postal-code": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "ship-country": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "gift-wrap-type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "gift-message-text": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "gift-wrap-price": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "gift-wrap-tax": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "item-promotion-discount": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "item-promotion-id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "shipping-promotion-discount": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "shipping-promotion-id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "delivery-instructions": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "order-channel": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "order-channel-instance": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "is-business-order": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "purchase-order-number": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "price-designation": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "buyer-company-name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "licensee-name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "license-number": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "license-state": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "license-expiration-date": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "Address-Type": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "Number-of-items": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "is-global-express": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "default-ship-from-address-name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "default-ship-from-address-field-1": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "default-ship-from-address-field-2": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "default-ship-from-address-field-3": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "default-ship-from-address-city": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "default-ship-from-address-state": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "default-ship-from-address-country": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "default-ship-from-address-postal-code": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "actual-ship-from-address-name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "actual-ship-from-address-1": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "actual-ship-from-address-field-2": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "actual-ship-from-address-field-3": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "actual-ship-from-address-city": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "actual-ship-from-address-state": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "actual-ship-from-address-country": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "actual-ship-from-address-postal-code": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        },
+        "supported_sync_modes": [
+          "full_refresh"
+        ]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "append"
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
@@ -377,6 +377,7 @@ class FlatFileOrdersReports(ReportsAmazonSPStream):
     """
 
     name = "GET_FLAT_FILE_ALL_ORDERS_DATA_BY_ORDER_DATE_GENERAL"
+    cursor_field = "purchase-date"
 
 
 class FbaInventoryReports(ReportsAmazonSPStream):


### PR DESCRIPTION
See `README.md` to set up local environment.

Set up `secrets/config-boba-us.json`:
```
{
  "app_id": "XXX",
  "lwa_app_id": "XXX",
  "lwa_client_secret": "XXX",
  "refresh_token": "XXX",

  "aws_access_key": "XXX",
  "aws_secret_key": "XXX,
  "role_arn": "arn:aws:iam::627645648883:role/SellingPartnerAPI",
  "aws_environment": "PRODUCTION",
  "region": "US",
  "replication_start_date": "2022-09-01T00:00:00Z"
}
```

The `discover` command will return all available streams within the amazon seller partner connector:
```
python main.py discover --config secrets/config-boba-us.json 
```
The `supported_sync_modes` field shows if we can stream using `incremental` mode, or only using `full_refresh`.

To enable the `incremental` streaming, we need to add the correct `cursor_field` within the report class defined in `streams.py`. If we then run `discover` again, you can see the `supported_sync_modes` will include both `incremental` and `full_refresh`.
